### PR TITLE
1 add sensors data api endpoint

### DIFF
--- a/src/solaredge_interface/api/SolarEdgeAPI.py
+++ b/src/solaredge_interface/api/SolarEdgeAPI.py
@@ -437,6 +437,23 @@ class SolarEdgeAPI:
             params['meters'] = meters
         return self.__response_wrapper(http_request(url, params), site_id=site_id)
 
+    def get_site_sensors(self, site_id, start_time, end_time):
+        """
+        Returns a list of all the sensors in the site, and the device to which they are connected.
+
+        _parameters_
+        * _site_id_ (int) required - The site identifier to retrieve data for.
+        * _start_time_ (str) required - must be in format YYYY-MM-DD hh:mm:ss
+        * _end_time_ (str) required - must be in format YYYY-MM-DD hh:mm:ss
+        """
+        url = url_join(BASEURL, "site", site_id, "sensors")
+        params = {
+            'api_key': self.api_key,
+            'startTime': start_time,
+            'endTime': end_time
+        }
+        return self.__response_wrapper(http_request(url, params), site_id=site_id)
+
     def get_site_equipment_sensors(self, site_id):
         """
         Returns a list of all the sensors in the site, and the device to which they are connected.

--- a/src/solaredge_interface/cli/click.py
+++ b/src/solaredge_interface/cli/click.py
@@ -339,6 +339,22 @@ def get_site_meters(**kwargs):
         output_format=solaredge_cli_config.format
     )
 
+@solaredge_interface.command('site_sensors')
+@click.argument('site_id', required=False)
+@click.option('--start_time', help='Default 7 days ago, else format "YYYY-MM-DD hh:mm:ss"')
+@click.option('--end_time', help='Default now time, else format "YYYY-MM-DD hh:mm:ss"')
+def get_site_meters(**kwargs):
+    """
+    Returns a list of all the sensors in the site, and the device to which they are connected.
+    """
+    kwargs = arg_helper.site_id(kwargs, config=solaredge_cli_config)
+    kwargs = arg_helper.end_time(kwargs)
+    kwargs = arg_helper.start_time(kwargs, delta_time=-(3600*24*7))
+    format_output(
+        response=solaredge_api.get_site_sensors(**kwargs),
+        output_format=solaredge_cli_config.format
+    )
+
 
 @solaredge_interface.command('site_equipment_sensors')
 @click.argument('site_id', required=False)


### PR DESCRIPTION
This pull request adds the sensor data fetch endpoint (URL: `/equipment/{siteId}/sensors`) for both the SolaredgeAPI and cli. 